### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ paddleocr = "^2.9.1"
 paddlepaddle = "^2.6.2"
 setuptools = "^75.3.0"
 httpx = "^0.27.2"
-pillow = "^11.1"
+pillow = ">=11.1,<11.2"
 emoji = "^2.14"
 
 [build-system]


### PR DESCRIPTION
pillow中的_multiline_spacing在 `11.2.x` 被移除了 需要使用 `11.1.x` 及以下版本