### PR TITLE
更新群组检测相关功能、新增艾特查询功能、优化部分功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,5 @@ cover/
 # Translations
 *.mo
 *.pot
+
+.vscode/

--- a/nonebot_plugin_quote/__init__.py
+++ b/nonebot_plugin_quote/__init__.py
@@ -286,7 +286,7 @@ async def record_pool_handle(bot: Bot, event: Event, state: T_State, Session: Ev
                 length = len(record_dict[groupNum])
                 idx = random.randint(0, length - 1)
                 msg = '当前查询无结果, 为您随机发送。'
-                msg_segment = MessageSegment.image(file=record_dict[groupNum][idx])
+                msg = MessageSegment.image(file=os.path.abspath(os.path.join(quote_path, os.path.basename(record_dict[groupNum][idx]))))
                 msg = msg + msg_segment
 
         elif search_info == '':

--- a/nonebot_plugin_quote/__init__.py
+++ b/nonebot_plugin_quote/__init__.py
@@ -94,6 +94,24 @@ try:
 except Exception as e:
     logger.error(f'错误: {e}! ')
 
+# 运行前将绝对路径修改为相对路径
+try:
+    for i in record_dict:
+        for idx, val in enumerate(record_dict[i]):
+            record_dict[i][idx] = os.path.basename(val)
+    with open(plugin_config.record_path, 'w', encoding='UTF-8') as f:
+        json.dump(record_dict, f, indent=4, ensure_ascii=False)
+
+    for i in inverted_index:
+        for j in inverted_index[i]:
+            for idx, val in enumerate(inverted_index[i][j]):
+                inverted_index[i][j][idx] = os.path.basename(val)
+    with open(plugin_config.inverted_index_path, 'w', encoding='UTF-8') as f:
+        json.dump(inverted_index, f, indent=4, ensure_ascii=False)
+    logger.info('已去除语录数据库中的绝对路径内容')
+except Exception as e:
+    logger.error(f'错误: {e}! ')
+
 forward_index = inverted2forward(inverted_index)
 
 

--- a/nonebot_plugin_quote/__init__.py
+++ b/nonebot_plugin_quote/__init__.py
@@ -5,6 +5,7 @@ from nonebot.params import Arg, ArgPlainText, CommandArg
 from nonebot.adapters.onebot.v11 import Bot, Event, Message, MessageEvent, PrivateMessageEvent, MessageSegment, exception
 from nonebot.typing import T_State  
 from nonebot.plugin import PluginMetadata
+from nonebot_plugin_session import EventSession
 import re
 import json
 import random
@@ -132,7 +133,7 @@ async def reply_handle(bot, errMsg, raw_message, groupNum, user_id, listener):
 save_img = on_regex(pattern="^{}上传$".format(re.escape(plugin_config.quote_startcmd)), **need_at)
 
 @save_img.handle()
-async def save_img_handle(bot: Bot, event: MessageEvent, state: T_State):
+async def save_img_handle(bot: Bot, event: MessageEvent, state: T_State, Session: EventSession):
 
     session_id = event.get_session_id()
     message_id = event.message_id
@@ -192,12 +193,11 @@ async def save_img_handle(bot: Bot, event: MessageEvent, state: T_State):
 
 
     if 'group' in session_id:
-        tmpList = session_id.split('_')
-        groupNum = tmpList[1]
+        groupNum = Session.id2
 
         inverted_index, forward_index = offer(groupNum, image_path, ocr_content, inverted_index, forward_index)
 
-        if groupNum not in record_dict:
+        if groupNum not in list(record_dict.keys()):
             record_dict[groupNum] = [image_path]
         else:
             if image_path not in record_dict[groupNum]:
@@ -219,7 +219,7 @@ async def save_img_handle(bot: Bot, event: MessageEvent, state: T_State):
 record_pool = on_startswith('{}语录'.format(plugin_config.quote_startcmd), priority=2, block=True, **need_at)
 
 @record_pool.handle()
-async def record_pool_handle(bot: Bot, event: Event, state: T_State):
+async def record_pool_handle(bot: Bot, event: Event, state: T_State, Session: EventSession):
 
     session_id = event.get_session_id()
     user_id = str(event.get_user_id())
@@ -232,11 +232,10 @@ async def record_pool_handle(bot: Bot, event: Event, state: T_State):
         search_info = str(event.get_message()).strip()
         search_info = search_info.replace('{}语录'.format(plugin_config.quote_startcmd), '').replace(' ', '')
 
-        tmpList = session_id.split('_')
-        groupNum = tmpList[1]
+        groupNum = Session.id2
 
         if search_info == '':
-            if groupNum not in record_dict:
+            if groupNum not in list(record_dict.keys()):
                 msg = '当前无语录库'
             else:
                 length = len(record_dict[groupNum])
@@ -248,7 +247,7 @@ async def record_pool_handle(bot: Bot, event: Event, state: T_State):
             if ret['status'] == -1:
                 msg = '当前无语录库'
             elif ret['status'] == 2:
-                if groupNum not in record_dict:
+                if groupNum not in list(record_dict.keys()):
                     msg = '当前无语录库'
                 else:
                     length = len(record_dict[groupNum])
@@ -271,7 +270,7 @@ async def record_pool_handle(bot: Bot, event: Event, state: T_State):
 record_help = on_keyword({"语录"}, priority=10, rule=to_me())
 
 @record_help.handle()
-async def record_help_handle(bot: Bot, event: Event, state: T_State):
+async def record_help_handle(bot: Bot, event: Event, state: T_State, Session: EventSession):
 
     session_id = event.get_session_id()
     user_id = str(event.get_user_id())
@@ -282,8 +281,7 @@ async def record_help_handle(bot: Bot, event: Event, state: T_State):
     msg = '''您可以通过回复指定图片, 发送【上传】指令上传语录。您也可以直接发送【语录】指令, 我将随机返回一条语录。'''
 
     if 'group' in session_id:
-        tmpList = session_id.split('_')
-        groupNum = tmpList[1]
+        groupNum = Session.id2
 
         await bot.call_api('send_group_msg', **{
             'group_id': int(groupNum),
@@ -436,7 +434,7 @@ async def deltag_handle(bot: Bot, event: Event, state: T_State):
 make_record = on_regex(pattern="^{}记录$".format(re.escape(plugin_config.quote_startcmd)))
 
 @make_record.handle()
-async def make_record_handle(bot: Bot, event: MessageEvent, state: T_State):
+async def make_record_handle(bot: Bot, event: MessageEvent, state: T_State, Session: EventSession):
 
     if not check_font(font_path, author_font_path):
         # 字体没配置就返回
@@ -492,12 +490,11 @@ async def make_record_handle(bot: Bot, event: MessageEvent, state: T_State):
                 file.write(img_data)
 
             if 'group' in session_id:
-                tmpList = session_id.split('_')
-                groupNum = tmpList[1]
+                        groupNum = Session.id2
 
                 inverted_index, forward_index = offer(groupNum, image_path, card + ' ' + raw_message, inverted_index, forward_index)
 
-                if groupNum not in record_dict:
+                if groupNum not in list(record_dict.keys()):
                     record_dict[groupNum] = [image_path]
                 else:
                     if image_path not in record_dict[groupNum]:

--- a/nonebot_plugin_quote/__init__.py
+++ b/nonebot_plugin_quote/__init__.py
@@ -274,7 +274,7 @@ async def record_pool_handle(bot: Bot, event: Event, state: T_State, Session: Ev
                 break
 
         if ats:
-            # try:
+            try:
                 target_ats_list = []
                 for i in record_dict[groupNum]:
                     if i.startswith(f"{ats}_"):
@@ -282,12 +282,12 @@ async def record_pool_handle(bot: Bot, event: Event, state: T_State, Session: Ev
                 length = len(target_ats_list)
                 idx = random.randint(0, length - 1)
                 msg = MessageSegment.image(file=os.path.abspath(os.path.join(quote_path, os.path.basename(target_ats_list[idx]))))
-            # except:
-            #     length = len(record_dict[groupNum])
-            #     idx = random.randint(0, length - 1)
-            #     msg = '当前查询无结果, 为您随机发送。'
-            #     msg_segment = MessageSegment.image(file=record_dict[groupNum][idx])
-            #     msg = msg + msg_segment
+            except:
+                length = len(record_dict[groupNum])
+                idx = random.randint(0, length - 1)
+                msg = '当前查询无结果, 为您随机发送。'
+                msg_segment = MessageSegment.image(file=record_dict[groupNum][idx])
+                msg = msg + msg_segment
 
         elif search_info == '':
             if groupNum not in list(record_dict.keys()):

--- a/nonebot_plugin_quote/task.py
+++ b/nonebot_plugin_quote/task.py
@@ -55,6 +55,17 @@ def query(sentence, group_id, inverted_index):
     return {'status': 1, 'msg': result_pool[idx]}
 
 
+def _remove(arr, ele):
+    old_len = len(arr)
+    for name in arr:
+        file_name = os.path.basename(name)
+        if file_name.endswith(ele):
+            arr.remove(name)
+            break
+    
+    return len(arr) < old_len
+
+
 # 删除内容
 def delete(img_name, group_id, record, inverted_index, forward_index):
     check = False
@@ -71,24 +82,13 @@ def delete(img_name, group_id, record, inverted_index, forward_index):
 
         for key in forward_index[group_id].keys():
             file_name = os.path.basename(key)
-            if file_name.startswith(img_name):
+            if file_name.endswith(img_name):
                 del forward_index[group_id][key]
                 break
 
         return check, record, inverted_index, forward_index
     except KeyError:
         return check, record, inverted_index, forward_index
-
-
-def _remove(arr, ele):
-    old_len = len(arr)
-    for name in arr:
-        file_name = os.path.basename(name)
-        if file_name.startswith(ele):
-            arr.remove(name)
-            break
-    
-    return len(arr) < old_len
 
 
 
@@ -147,7 +147,7 @@ def inverted2forward(inverted_index):
 def findAlltag(img_name, forward_index, group_id):
     for key, value in forward_index[group_id].items():
         file_name = os.path.basename(key)
-        if file_name.startswith(img_name):
+        if file_name.endswith(img_name):
             return value
 
 
@@ -157,7 +157,7 @@ def addTag(tags, img_name, group_id, forward_index, inverted_index):
     path = None
     for key in forward_index[group_id].keys():
         file_name = os.path.basename(key)
-        if file_name.startswith(img_name):
+        if file_name.endswith(img_name):
             path = key
             for tag in tags:
                 forward_index[group_id][key].add(tag)
@@ -174,7 +174,7 @@ def delTag(tags, img_name, group_id, forward_index, inverted_index):
     path = None
     for key in forward_index[group_id].keys():
         file_name = os.path.basename(key)
-        if file_name.startswith(img_name):
+        if file_name.endswith(img_name):
             path = key
             for tag in tags:
                 forward_index[group_id][key].discard(tag)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ setuptools = "^75.3.0"
 httpx = ">=0.27.2"
 pillow = ">=11.1,<11.2"
 emoji = "^2.14"
+nonebot-plugin-session = "^0.3.2"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
1. 改用nonebot-plugin-session获取group_id
2. 改用list(record_dict.keys())而非直接判断group_id是否存在于record_dict
3. 添加艾特查询功能，使用`语录+@{群员}`时可获取相应的语录。
<img width="438" height="253" alt="image" src="https://github.com/user-attachments/assets/18862d49-6f1a-423f-a45e-5895f67b1c9a" /> </br>
4. 删除json.dump中多余的separators参数。</br>
5. 修改文件名存储json。当上传/记录时仅记录文件名而非完整的文件路径。发送时再使用os.path.join生成完整的文件路径。</br>
6. 为了适配艾特查询功能，语录记录时文件存储名格式更改为`{被回复的QQ}_{hash值}.png`，与原有的随机获取语录功能不受影响</br>
7. task.delete函数改为了endswith以查找目标被删除的文件。</br>
8. 在运行前通过list(set())去除数据库中的重复内容。</br>
9. 在运行前将原有的数据库中绝对路径修改为仅文件名，如后续版本更新则无需手动修改数据库