### PR TITLE
仿QQ原生样式

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,5 @@ cover/
 # Translations
 *.mo
 *.pot
+
+.vscode/

--- a/nonebot_plugin_quote/__init__.py
+++ b/nonebot_plugin_quote/__init__.py
@@ -286,7 +286,7 @@ async def record_pool_handle(bot: Bot, event: Event, state: T_State, Session: Ev
                 length = len(record_dict[groupNum])
                 idx = random.randint(0, length - 1)
                 msg = '当前查询无结果, 为您随机发送。'
-                msg_segment = MessageSegment.image(file=record_dict[groupNum][idx])
+                msg = MessageSegment.image(file=os.path.abspath(os.path.join(quote_path, os.path.basename(record_dict[groupNum][idx]))))
                 msg = msg + msg_segment
 
         elif search_info == '':

--- a/nonebot_plugin_quote/__init__.py
+++ b/nonebot_plugin_quote/__init__.py
@@ -94,6 +94,24 @@ try:
 except Exception as e:
     logger.error(f'错误: {e}! ')
 
+# 运行前将绝对路径修改为相对路径
+try:
+    for i in record_dict:
+        for idx, val in enumerate(record_dict[i]):
+            record_dict[i][idx] = os.path.basename(val)
+    with open(plugin_config.record_path, 'w', encoding='UTF-8') as f:
+        json.dump(record_dict, f, indent=4, ensure_ascii=False)
+
+    for i in inverted_index:
+        for j in inverted_index[i]:
+            for idx, val in enumerate(inverted_index[i][j]):
+                inverted_index[i][j][idx] = os.path.basename(val)
+    with open(plugin_config.inverted_index_path, 'w', encoding='UTF-8') as f:
+        json.dump(inverted_index, f, indent=4, ensure_ascii=False)
+    logger.info('已去除语录数据库中的绝对路径内容')
+except Exception as e:
+    logger.error(f'错误: {e}! ')
+
 forward_index = inverted2forward(inverted_index)
 
 

--- a/nonebot_plugin_quote/__init__.py
+++ b/nonebot_plugin_quote/__init__.py
@@ -5,6 +5,7 @@ from nonebot.params import Arg, ArgPlainText, CommandArg
 from nonebot.adapters.onebot.v11 import Bot, Event, Message, MessageEvent, PrivateMessageEvent, MessageSegment, exception
 from nonebot.typing import T_State  
 from nonebot.plugin import PluginMetadata
+from nonebot_plugin_session import EventSession
 import re
 import json
 import random
@@ -132,7 +133,7 @@ async def reply_handle(bot, errMsg, raw_message, groupNum, user_id, listener):
 save_img = on_regex(pattern="^{}上传$".format(re.escape(plugin_config.quote_startcmd)), **need_at)
 
 @save_img.handle()
-async def save_img_handle(bot: Bot, event: MessageEvent, state: T_State):
+async def save_img_handle(bot: Bot, event: MessageEvent, state: T_State, Session: EventSession):
 
     session_id = event.get_session_id()
     message_id = event.message_id
@@ -192,12 +193,11 @@ async def save_img_handle(bot: Bot, event: MessageEvent, state: T_State):
 
 
     if 'group' in session_id:
-        tmpList = session_id.split('_')
-        groupNum = tmpList[1]
+        groupNum = Session.id2
 
         inverted_index, forward_index = offer(groupNum, image_path, ocr_content, inverted_index, forward_index)
 
-        if groupNum not in record_dict:
+        if groupNum not in list(record_dict.keys()):
             record_dict[groupNum] = [image_path]
         else:
             if image_path not in record_dict[groupNum]:
@@ -219,7 +219,7 @@ async def save_img_handle(bot: Bot, event: MessageEvent, state: T_State):
 record_pool = on_startswith('{}语录'.format(plugin_config.quote_startcmd), priority=2, block=True, **need_at)
 
 @record_pool.handle()
-async def record_pool_handle(bot: Bot, event: Event, state: T_State):
+async def record_pool_handle(bot: Bot, event: Event, state: T_State, Session: EventSession):
 
     session_id = event.get_session_id()
     user_id = str(event.get_user_id())
@@ -232,11 +232,10 @@ async def record_pool_handle(bot: Bot, event: Event, state: T_State):
         search_info = str(event.get_message()).strip()
         search_info = search_info.replace('{}语录'.format(plugin_config.quote_startcmd), '').replace(' ', '')
 
-        tmpList = session_id.split('_')
-        groupNum = tmpList[1]
+        groupNum = Session.id2
 
         if search_info == '':
-            if groupNum not in record_dict:
+            if groupNum not in list(record_dict.keys()):
                 msg = '当前无语录库'
             else:
                 length = len(record_dict[groupNum])
@@ -248,7 +247,7 @@ async def record_pool_handle(bot: Bot, event: Event, state: T_State):
             if ret['status'] == -1:
                 msg = '当前无语录库'
             elif ret['status'] == 2:
-                if groupNum not in record_dict:
+                if groupNum not in list(record_dict.keys()):
                     msg = '当前无语录库'
                 else:
                     length = len(record_dict[groupNum])
@@ -271,7 +270,7 @@ async def record_pool_handle(bot: Bot, event: Event, state: T_State):
 record_help = on_keyword({"语录"}, priority=10, rule=to_me())
 
 @record_help.handle()
-async def record_help_handle(bot: Bot, event: Event, state: T_State):
+async def record_help_handle(bot: Bot, event: Event, state: T_State, Session: EventSession):
 
     session_id = event.get_session_id()
     user_id = str(event.get_user_id())
@@ -282,8 +281,7 @@ async def record_help_handle(bot: Bot, event: Event, state: T_State):
     msg = '''您可以通过回复指定图片, 发送【上传】指令上传语录。您也可以直接发送【语录】指令, 我将随机返回一条语录。'''
 
     if 'group' in session_id:
-        tmpList = session_id.split('_')
-        groupNum = tmpList[1]
+        groupNum = Session.id2
 
         await bot.call_api('send_group_msg', **{
             'group_id': int(groupNum),
@@ -436,7 +434,7 @@ async def deltag_handle(bot: Bot, event: Event, state: T_State):
 make_record = on_regex(pattern="^{}记录$".format(re.escape(plugin_config.quote_startcmd)))
 
 @make_record.handle()
-async def make_record_handle(bot: Bot, event: MessageEvent, state: T_State):
+async def make_record_handle(bot: Bot, event: MessageEvent, state: T_State, Session: EventSession):
 
     if not check_font(font_path, author_font_path):
         # 字体没配置就返回
@@ -492,12 +490,11 @@ async def make_record_handle(bot: Bot, event: MessageEvent, state: T_State):
                 file.write(img_data)
 
             if 'group' in session_id:
-                tmpList = session_id.split('_')
-                groupNum = tmpList[1]
+                        groupNum = Session.id2
 
                 inverted_index, forward_index = offer(groupNum, image_path, card + ' ' + raw_message, inverted_index, forward_index)
 
-                if groupNum not in record_dict:
+                if groupNum not in list(record_dict.keys()):
                     record_dict[groupNum] = [image_path]
                 else:
                     if image_path not in record_dict[groupNum]:

--- a/nonebot_plugin_quote/__init__.py
+++ b/nonebot_plugin_quote/__init__.py
@@ -274,7 +274,7 @@ async def record_pool_handle(bot: Bot, event: Event, state: T_State, Session: Ev
                 break
 
         if ats:
-            # try:
+            try:
                 target_ats_list = []
                 for i in record_dict[groupNum]:
                     if i.startswith(f"{ats}_"):
@@ -282,12 +282,12 @@ async def record_pool_handle(bot: Bot, event: Event, state: T_State, Session: Ev
                 length = len(target_ats_list)
                 idx = random.randint(0, length - 1)
                 msg = MessageSegment.image(file=os.path.abspath(os.path.join(quote_path, os.path.basename(target_ats_list[idx]))))
-            # except:
-            #     length = len(record_dict[groupNum])
-            #     idx = random.randint(0, length - 1)
-            #     msg = '当前查询无结果, 为您随机发送。'
-            #     msg_segment = MessageSegment.image(file=record_dict[groupNum][idx])
-            #     msg = msg + msg_segment
+            except:
+                length = len(record_dict[groupNum])
+                idx = random.randint(0, length - 1)
+                msg = '当前查询无结果, 为您随机发送。'
+                msg_segment = MessageSegment.image(file=record_dict[groupNum][idx])
+                msg = msg + msg_segment
 
         elif search_info == '':
             if groupNum not in list(record_dict.keys()):

--- a/nonebot_plugin_quote/__init__.py
+++ b/nonebot_plugin_quote/__init__.py
@@ -584,7 +584,9 @@ async def make_record_handle(bot: Bot, event: MessageEvent, state: T_State, Sess
 render_quote = on_regex(pattern="^{}生成$".format(re.escape(plugin_config.quote_startcmd)))
 
 @render_quote.handle()
-async def render_quote_handle(bot: Bot, event: MessageEvent, state: T_State):
+async def render_quote_handle(bot: Bot, event: MessageEvent, state: T_State, Session: EventSession):
+
+    group_id = Session.id2
 
     if not check_font(font_path, author_font_path, emulating_font_path):
         # 字体没配置就返回
@@ -626,12 +628,15 @@ async def render_quote_handle(bot: Bot, event: MessageEvent, state: T_State):
             data = await download_url(url)
 
         if data:
-            image_file = io.BytesIO(data)
-            img_data = generate_quote_image(image_file, raw_message, card, font_path, author_font_path)
+            if plugin_config.emulating_native_qq_style:
+                img_data = await generate_emulating_native_qq_style_image(int(qqid), int(group_id), f"file:///{emulating_font_path}",  raw_message, bot)
+            else:
+                image_file = io.BytesIO(data)
+                img_data = generate_quote_image(image_file, raw_message, card, font_path, author_font_path)
             
             msg = MessageSegment.image(img_data)
             response = await bot.call_api('send_group_msg', **{
-                'group_id': int(session_id.split('_')[1]),
+                'group_id': int(group_id),
                 'message': msg
             })
     else:

--- a/nonebot_plugin_quote/config.py
+++ b/nonebot_plugin_quote/config.py
@@ -13,7 +13,9 @@ class Config(BaseModel, extra=Extra.ignore):
     quote_path: str = 'quote'
     font_path: str = 'font1'
     author_font_path: str = 'font2'
+    emulating_native_qq_style: bool = False
+    emulating_font_path: str = 'font3'
 
-def check_font(font_path, author_font_path):
+def check_font(font_path, author_font_path, emulating_font_path):
     # 判断字体是否配置
-    return not (font_path == 'font1' or author_font_path == 'font2')
+    return not (font_path == 'font1' or author_font_path == 'font2' or emulating_font_path == 'font3')

--- a/nonebot_plugin_quote/qq_make_image.py
+++ b/nonebot_plugin_quote/qq_make_image.py
@@ -1,0 +1,50 @@
+from jinja2 import Environment, FileSystemLoader
+from playwright.async_api import async_playwright
+import os,requests
+from nonebot.adapters.onebot.v11 import Bot
+
+env = Environment(loader=FileSystemLoader(os.path.dirname(os.path.abspath(__file__))))
+template = env.get_template('template.html')
+
+async def generate_emulating_native_qq_style_image(userid: int, groupid: int, fontpath: str,  raw_message: str, bot: Bot, max_width=600, scale=3) -> bytes:
+    response = await bot.call_api('get_group_member_info', **{
+                'group_id': groupid,
+                'user_id': userid
+            })
+    data = {
+        "messages": [
+            {
+                "username": response['card_or_nickname'],
+                "level": int(response['level']),
+                "user_type": response['role'],
+                "avatar": f"https://q.qlogo.cn/g?b=qq&nk={userid}&s=640",
+                "message": raw_message
+            }
+        ],
+        "font_path": fontpath
+    }
+
+    print (data)
+
+    html_content = template.render(**data)
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page(viewport={'width': max_width, 'height': 100}, device_scale_factor=scale)
+
+        await page.set_content(html_content, wait_until='networkidle')
+
+        dimensions = await page.evaluate('''() => {
+            const wrapper = document.querySelector(".chat-wrapper");
+            return {
+                width: wrapper.scrollWidth,
+                height: wrapper.scrollHeight
+            };
+        }''')
+
+        actual_width = min(max(dimensions['width'], 300), max_width)
+        await page.set_viewport_size({'width': int(actual_width), 'height': int(dimensions['height'])})
+
+        img = await page.screenshot()
+        await browser.close()
+        return img

--- a/nonebot_plugin_quote/qq_make_image.py
+++ b/nonebot_plugin_quote/qq_make_image.py
@@ -6,11 +6,12 @@ from nonebot.adapters.onebot.v11 import Bot
 env = Environment(loader=FileSystemLoader(os.path.dirname(os.path.abspath(__file__))))
 template = env.get_template('template.html')
 
-async def generate_emulating_native_qq_style_image(userid: int, groupid: int, fontpath: str,  raw_message: str, bot: Bot, max_width=600, scale=3) -> bytes:
+async def generate_emulating_native_qq_style_image(userid: int, groupid: int, fontpath: str,  raw_message: list, bot: Bot, max_width=600, scale=3) -> bytes:
     response = await bot.call_api('get_group_member_info', **{
                 'group_id': groupid,
                 'user_id': userid
             })
+    
     data = {
         "messages": [
             {
@@ -18,11 +19,25 @@ async def generate_emulating_native_qq_style_image(userid: int, groupid: int, fo
                 "level": int(response['level']),
                 "user_type": response['role'],
                 "avatar": f"https://q.qlogo.cn/g?b=qq&nk={userid}&s=640",
-                "message": raw_message
+                "message": ""
             }
         ],
         "font_path": fontpath
-    }
+        }
+    
+    
+    for i in raw_message:
+        # data['messages'].append({
+        #     "username": response['card_or_nickname'],
+        #     "level": int(response['level']),
+        #     "user_type": response['role'],
+        #     "avatar": f"https://q.qlogo.cn/g?b=qq&nk={userid}&s=640",
+        #     "message": i[1]
+        #     })
+        data["messages"][0]["message"] += i[1]
+        if len(raw_message) != 1:
+            if i[0] == "image":
+                    data["messages"][0]["message"] += "\n"
 
     html_content = template.render(**data)
 

--- a/nonebot_plugin_quote/qq_make_image.py
+++ b/nonebot_plugin_quote/qq_make_image.py
@@ -24,8 +24,6 @@ async def generate_emulating_native_qq_style_image(userid: int, groupid: int, fo
         "font_path": fontpath
     }
 
-    print (data)
-
     html_content = template.render(**data)
 
     async with async_playwright() as p:

--- a/nonebot_plugin_quote/qq_make_image.py
+++ b/nonebot_plugin_quote/qq_make_image.py
@@ -19,6 +19,7 @@ async def generate_emulating_native_qq_style_image(userid: int, groupid: int, fo
                 "level": int(response['level']),
                 "user_type": response['role'],
                 "avatar": f"https://q.qlogo.cn/g?b=qq&nk={userid}&s=640",
+                "title": response['title']
                 "message": ""
             }
         ],

--- a/nonebot_plugin_quote/task.py
+++ b/nonebot_plugin_quote/task.py
@@ -55,6 +55,17 @@ def query(sentence, group_id, inverted_index):
     return {'status': 1, 'msg': result_pool[idx]}
 
 
+def _remove(arr, ele):
+    old_len = len(arr)
+    for name in arr:
+        file_name = os.path.basename(name)
+        if file_name.endswith(ele):
+            arr.remove(name)
+            break
+    
+    return len(arr) < old_len
+
+
 # 删除内容
 def delete(img_name, group_id, record, inverted_index, forward_index):
     check = False
@@ -71,24 +82,13 @@ def delete(img_name, group_id, record, inverted_index, forward_index):
 
         for key in forward_index[group_id].keys():
             file_name = os.path.basename(key)
-            if file_name.startswith(img_name):
+            if file_name.endswith(img_name):
                 del forward_index[group_id][key]
                 break
 
         return check, record, inverted_index, forward_index
     except KeyError:
         return check, record, inverted_index, forward_index
-
-
-def _remove(arr, ele):
-    old_len = len(arr)
-    for name in arr:
-        file_name = os.path.basename(name)
-        if file_name.startswith(ele):
-            arr.remove(name)
-            break
-    
-    return len(arr) < old_len
 
 
 
@@ -147,7 +147,7 @@ def inverted2forward(inverted_index):
 def findAlltag(img_name, forward_index, group_id):
     for key, value in forward_index[group_id].items():
         file_name = os.path.basename(key)
-        if file_name.startswith(img_name):
+        if file_name.endswith(img_name):
             return value
 
 
@@ -157,7 +157,7 @@ def addTag(tags, img_name, group_id, forward_index, inverted_index):
     path = None
     for key in forward_index[group_id].keys():
         file_name = os.path.basename(key)
-        if file_name.startswith(img_name):
+        if file_name.endswith(img_name):
             path = key
             for tag in tags:
                 forward_index[group_id][key].add(tag)
@@ -174,7 +174,7 @@ def delTag(tags, img_name, group_id, forward_index, inverted_index):
     path = None
     for key in forward_index[group_id].keys():
         file_name = os.path.basename(key)
-        if file_name.startswith(img_name):
+        if file_name.endswith(img_name):
             path = key
             for tag in tags:
                 forward_index[group_id][key].discard(tag)

--- a/nonebot_plugin_quote/template.html
+++ b/nonebot_plugin_quote/template.html
@@ -79,6 +79,8 @@ body {
     align-items: center;
     height: 20px;
     line-height: 1;
+    white-space: nowrap;
+    flex-shrink: 0; 
 }
 
 .level.member {

--- a/nonebot_plugin_quote/template.html
+++ b/nonebot_plugin_quote/template.html
@@ -75,7 +75,6 @@
     align-items: center;
     height: 20px;
     line-height: 1;
-    padding-right: 5px;
 }
 
         .level {

--- a/nonebot_plugin_quote/template.html
+++ b/nonebot_plugin_quote/template.html
@@ -19,7 +19,7 @@ body {
 }
 
 .chat-wrapper {
-    background: white;
+    background: #f0f0f0;
     border-radius: 12px;
     padding: 20px;
     box-shadow: 0 4px 12px rgba(0,0,0,0.1);

--- a/nonebot_plugin_quote/template.html
+++ b/nonebot_plugin_quote/template.html
@@ -77,33 +77,16 @@ body {
     line-height: 1;
 }
 
-.level.member {
-    background-color: #E2E2E2;
-    color: #a2a2a2;
-}
-
 .level.admin {
     background-color: #CEEEEB;
     color: #82C1B0;
     padding-right: 6px;
 }
 
-.level.admin::after {
-    content: "管理员";
-    margin-left: 2px;
-    font-size: 12px;
-}
-
 .level.owner {
     background-color: #F5DDCB;
     color: #FF9B3B;
     padding-right: 6px;
-}
-
-.level.owner::after {
-    content: "群主";
-    margin-left: 2px;
-    font-size: 12px;
 }
 
 .message-text {
@@ -140,13 +123,23 @@ body {
             <div class="message-block">
                 <div class="username-level">
                     <span class="username">{{ msg.username }}</span>
+
                     {% if msg.user_type == 'member' %}
-                        <span class="level member">LV{{ msg.level }}</span>
+                        <span class="level member"
+                              style="background-color: {% if msg.title %}#e4daf3{% else %}#E2E2E2{% endif %};
+                                     color: {% if msg.title %}#b589f6{% else %}#a2a2a2{% endif %};">
+                            LV{{ msg.level }}{% if msg.title %} {{ msg.title }}{% endif %}
+                        </span>
                     {% elif msg.user_type == 'admin' %}
-                        <span class="level admin">LV{{ msg.level }}</span>
+                        <span class="level admin">
+                            LV{{ msg.level }}{% if msg.title %} {{ msg.title }}{% else %} 管理员{% endif %}
+                        </span>
                     {% elif msg.user_type == 'owner' %}
-                        <span class="level owner">LV{{ msg.level }}</span>
+                        <span class="level owner">
+                            LV{{ msg.level }}{% if msg.title %} {{ msg.title }}{% else %} 群主{% endif %}
+                        </span>
                     {% endif %}
+
                 </div>
                 <div class="message-text">{{ msg.message.replace('\n', '<br>') | safe }}</div>
             </div>

--- a/nonebot_plugin_quote/template.html
+++ b/nonebot_plugin_quote/template.html
@@ -19,16 +19,19 @@ body {
 }
 
 .chat-wrapper {
-    padding: 20px 30px;
+    background: white;
+    border-radius: 12px;
+    padding: 20px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    max-width: 600px;
+    width: auto;
     display: inline-block;
 }
 
 .chat-container {
     display: flex;
     flex-direction: column;
-    gap: 12px;
-    max-width: 600px;
-    min-width: 200px;
+    gap: 16px;
 }
 
 .chat-message {
@@ -40,12 +43,15 @@ body {
     width: 40px;
     height: 40px;
     border-radius: 50%;
-    margin-right: 10px;
+    margin-right: 12px;
+    background: #e0e0e0;
 }
 
 .message-block {
     display: flex;
     flex-direction: column;
+    flex: 1;
+    max-width: calc(100% - 52px);
 }
 
 .username-level {
@@ -58,16 +64,18 @@ body {
 .username {
     font-size: 14px;
     color: #333;
-    white-space: nowrap;   /* 禁止换行 */
-    overflow: hidden;      /* 超出部分隐藏 */
-    text-overflow: ellipsis; /* 超出部分显示省略号 */
+    font-weight: 500;
 }
 
 .level {
     font-weight: bold;
-    padding: 1px 6px;
+    padding: 2px 6px;
     border-radius: 4px;
     font-size: 12px;
+    display: inline-flex;
+    align-items: center;
+    height: 20px;
+    line-height: 1;
 }
 
 .level.member {
@@ -78,11 +86,25 @@ body {
 .level.admin {
     background-color: #CEEEEB;
     color: #82C1B0;
+    padding-right: 6px;
+}
+
+.level.admin::after {
+    content: "管理员";
+    margin-left: 2px;
+    font-size: 12px;
 }
 
 .level.owner {
     background-color: #F5DDCB;
     color: #FF9B3B;
+    padding-right: 6px;
+}
+
+.level.owner::after {
+    content: "群主";
+    margin-left: 2px;
+    font-size: 12px;
 }
 
 .message-text {
@@ -93,10 +115,11 @@ body {
     border-radius: 12px;
     min-width: fit-content; 
     width: fit-content;
-    max-width: 80%;
+    max-width: 100%;
     word-wrap: break-word;
     overflow-wrap: break-word;
     box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+    line-height: 1.4;
 }
 </style>
 </head>
@@ -112,12 +135,12 @@ body {
                     {% if msg.user_type == 'member' %}
                         <span class="level member">LV{{ msg.level }}</span>
                     {% elif msg.user_type == 'admin' %}
-                        <span class="level admin">LV{{ msg.level }} 管理员</span>
+                        <span class="level admin">LV{{ msg.level }}</span>
                     {% elif msg.user_type == 'owner' %}
-                        <span class="level owner">LV{{ msg.level }} 群主</span>
+                        <span class="level owner">LV{{ msg.level }}</span>
                     {% endif %}
                 </div>
-                <div class="message-text">{{ msg.message }}</div>
+                <div class="message-text">{{ msg.message.replace('\n', '<br>') | safe }}</div>
             </div>
         </div>
         {% endfor %}

--- a/nonebot_plugin_quote/template.html
+++ b/nonebot_plugin_quote/template.html
@@ -64,9 +64,6 @@ body {
     font-size: 14px;
     color: #333;
     font-weight: 500;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 }
 
 .level {
@@ -78,8 +75,6 @@ body {
     align-items: center;
     height: 20px;
     line-height: 1;
-    white-space: nowrap;
-    flex-shrink: 0; 
 }
 
 .level.member {
@@ -117,7 +112,7 @@ body {
     padding: 10px 14px;
     background: #fff;
     border-radius: 12px;
-    min-width: fit-content; 
+    min-width: fit-content;
     width: fit-content;
     max-width: 100%;
     word-wrap: break-word;
@@ -125,6 +120,15 @@ body {
     box-shadow: 0 2px 6px rgba(0,0,0,0.1);
     line-height: 1.4;
 }
+
+.message-text img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin-top: 1px;
+    margin-bottom: 4px;
+}
+
 </style>
 </head>
 <body>

--- a/nonebot_plugin_quote/template.html
+++ b/nonebot_plugin_quote/template.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<title>Chat UI</title>
+<style>
+@font-face {
+    font-family: 'CustomFont';
+    src: url('{{ font_path }}') format('truetype');
+}
+
+body {
+    font-family: 'CustomFont', sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #f0f0f0;
+    display: flex;
+    justify-content: center;
+}
+
+.chat-wrapper {
+    padding: 20px 30px;
+    display: inline-block;
+}
+
+.chat-container {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-width: 600px;
+    min-width: 200px;
+}
+
+.chat-message {
+    display: flex;
+    align-items: flex-start;
+}
+
+.avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    margin-right: 10px;
+}
+
+.message-block {
+    display: flex;
+    flex-direction: column;
+}
+
+.username-level {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 4px;
+}
+
+.username {
+    font-size: 14px;
+    color: #333;
+    white-space: nowrap;   /* 禁止换行 */
+    overflow: hidden;      /* 超出部分隐藏 */
+    text-overflow: ellipsis; /* 超出部分显示省略号 */
+}
+
+.level {
+    font-weight: bold;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 12px;
+}
+
+.level.member {
+    background-color: #E2E2E2;
+    color: #a2a2a2;
+}
+
+.level.admin {
+    background-color: #CEEEEB;
+    color: #82C1B0;
+}
+
+.level.owner {
+    background-color: #F5DDCB;
+    color: #FF9B3B;
+}
+
+.message-text {
+    display: inline-block;
+    font-size: 16px;
+    padding: 10px 14px;
+    background: #fff;
+    border-radius: 12px;
+    min-width: fit-content; 
+    width: fit-content;
+    max-width: 80%;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+</style>
+</head>
+<body>
+<div class="chat-wrapper">
+    <div class="chat-container">
+        {% for msg in messages %}
+        <div class="chat-message">
+            <img class="avatar" src="{{ msg.avatar }}" alt="avatar">
+            <div class="message-block">
+                <div class="username-level">
+                    <span class="username">{{ msg.username }}</span>
+                    {% if msg.user_type == 'member' %}
+                        <span class="level member">LV{{ msg.level }}</span>
+                    {% elif msg.user_type == 'admin' %}
+                        <span class="level admin">LV{{ msg.level }} 管理员</span>
+                    {% elif msg.user_type == 'owner' %}
+                        <span class="level owner">LV{{ msg.level }} 群主</span>
+                    {% endif %}
+                </div>
+                <div class="message-text">{{ msg.message }}</div>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+</body>
+</html>

--- a/nonebot_plugin_quote/template.html
+++ b/nonebot_plugin_quote/template.html
@@ -65,6 +65,9 @@ body {
     font-size: 14px;
     color: #333;
     font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .level {

--- a/nonebot_plugin_quote/template.html
+++ b/nonebot_plugin_quote/template.html
@@ -24,8 +24,8 @@ body {
     padding: 20px;
     box-shadow: 0 4px 12px rgba(0,0,0,0.1);
     max-width: 600px;
-    width: auto;
-    display: inline-block;
+    width: auto; /* 改为auto而不是100% */
+    display: inline-block; /* 确保宽度由内容决定 */
 }
 
 .chat-container {
@@ -51,7 +51,7 @@ body {
     display: flex;
     flex-direction: column;
     flex: 1;
-    max-width: calc(100% - 52px);
+    max-width: calc(100% - 52px); /* 头像宽度 + 边距 */
 }
 
 .username-level {
@@ -115,7 +115,7 @@ body {
     border-radius: 12px;
     min-width: fit-content; 
     width: fit-content;
-    max-width: 100%;
+    max-width: 100%; /* 确保不超过容器 */
     word-wrap: break-word;
     overflow-wrap: break-word;
     box-shadow: 0 2px 6px rgba(0,0,0,0.1);

--- a/nonebot_plugin_quote/template.html
+++ b/nonebot_plugin_quote/template.html
@@ -75,6 +75,7 @@ body {
     align-items: center;
     height: 20px;
     line-height: 1;
+    padding-right: 5px;
 }
 
 .level.admin {

--- a/nonebot_plugin_quote/template.html
+++ b/nonebot_plugin_quote/template.html
@@ -22,10 +22,9 @@ body {
     background: #f0f0f0;
     border-radius: 12px;
     padding: 20px;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
     max-width: 600px;
-    width: auto; /* 改为auto而不是100% */
-    display: inline-block; /* 确保宽度由内容决定 */
+    width: auto;
+    display: inline-block;
 }
 
 .chat-container {
@@ -51,7 +50,7 @@ body {
     display: flex;
     flex-direction: column;
     flex: 1;
-    max-width: calc(100% - 52px); /* 头像宽度 + 边距 */
+    max-width: calc(100% - 52px);
 }
 
 .username-level {
@@ -120,7 +119,7 @@ body {
     border-radius: 12px;
     min-width: fit-content; 
     width: fit-content;
-    max-width: 100%; /* 确保不超过容器 */
+    max-width: 100%;
     word-wrap: break-word;
     overflow-wrap: break-word;
     box-shadow: 0 2px 6px rgba(0,0,0,0.1);

--- a/nonebot_plugin_quote/test.json
+++ b/nonebot_plugin_quote/test.json
@@ -1,0 +1,71 @@
+{
+    "time": 1757819598,
+    "self_id": 2650167109,
+    "post_type": "message",
+    "sub_type": "normal",
+    "user_id": 1293945058,
+    "message_type": "group",
+    "message_id": 621890218,
+    "message": [
+        {
+            "type": "text",
+            "data": {
+                "text": "语录"
+            }
+        },
+        {
+            "type": "at",
+            "data": {
+                "qq": "2781826578",
+                "name": "AL-1S(CPU负载: 12.7%) "
+            }
+        },
+        {
+            "type": "text",
+            "data": {
+                "text": " "
+            }
+        }
+    ],
+    "original_message": [
+        {
+            "type": "text",
+            "data": {
+                "text": "语录"
+            }
+        },
+        {
+            "type": "at",
+            "data": {
+                "qq": "2781826578",
+                "name": "AL-1S (CPU负载: 12.7%) "
+            }
+        },
+        {
+            "type": "text",
+            "data": {
+                "text": " "
+            }
+        }
+    ],
+    "raw_message": "语录[CQ:at,qq=2781826578,name=AL-1S (CPU负载: 12.7%) ] ",
+    "font": 14,
+    "sender": {
+        "user_id": 1293945058,
+        "nickname": "barryblueice",
+        "sex": null,
+        "age": null,
+        "card": "",
+        "area": null,
+        "level": null,
+        "role": "owner",
+        "title": ""
+    },
+    "to_me": false,
+    "reply": null,
+    "group_id": 965313024,
+    "anonymous": null,
+    "message_seq": 8757,
+    "message_format": "array",
+    "group_name": "测试"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ setuptools = "^75.3.0"
 httpx = ">=0.27.2"
 pillow = ">=11.1,<11.2"
 emoji = "^2.14"
+nonebot-plugin-session = "^0.3.2"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ httpx = ">=0.27.2"
 pillow = ">=11.1,<11.2"
 emoji = "^2.14"
 nonebot-plugin-session = "^0.3.2"
+playwright = "^1.47.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
新增仿QQ原生样式，通过Jinja2+Playwright生成仿QQ风格的样式图片进行语录记录。#24
在仿QQ原生样式下，语录记录可支持图文混合记录。

<img width="942" height="312" alt="44094d4b33631f7aac4163363467d532" src="https://github.com/user-attachments/assets/213b8bda-2136-4724-8cc1-32dfd9c1ffe9" />

<img width="1002" height="330" alt="721fd196302c07a7341869aeea39a8ea" src="https://github.com/user-attachments/assets/16dc79a8-bfd8-4222-b4eb-64d5c6e530dd" />
<img width="441" height="803" alt="image" src="https://github.com/user-attachments/assets/8a1ca32c-2ad4-43cf-9c0c-d4c2b724adab" />

> [!CAUTION]
> 1. 该功能需用到Playwright渲染和图片生成。
> 2. 图文混合需使用仿QQ原生样式模式，原模式仅支持纯文字内容。

如使用新功能需在`.env`文件中添加下表中的配置：
| 配置项 | 必填 | 默认值 | 说明 |
|:-:|:-:|:-:|:-:|
|EMULATING_FONT_PATH|否|None|仿QQ风格样式所需的字体资源位置|
|EMULATING_NATIVE_QQ_STYLE|否|False|是否使用仿QQ风格样式进行记录|